### PR TITLE
Fix deserializeLambda being generated with bad string encoding

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+ /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved.
+ * ===========================================================================
+ */
+
 package com.sun.tools.javac.comp;
 
 import com.sun.tools.javac.code.Symbol.MethodHandleSymbol;
@@ -2421,7 +2427,8 @@ public class LambdaToMethod extends TreeTranslator {
 
         @Override
         protected void append(byte[] ba) {
-            sb.append(new String(ba));
+            Name name = names.fromUtf(ba);
+            sb.append(name.toString());
         }
 
         @Override


### PR DESCRIPTION
When javac creates the `deserializeLambda` method, the `externalize` method is
called on the class names needed in order to swap the `.` and `/` characters.
This is returned as a byte array, which is turned into a string by calling the
String constructor. However, the bytes are encoded in the JVM's UTF encoding,
which can result in the String constructor making a bad string if the platform
default encoding has different byte values for characters.
This commit uses the `Names.fromUtf` method also used in ClassWriter.java for
dealing with the externalized class names instead of the String constructor.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fix for https://github.com/eclipse/openj9/issues/9168