### PR TITLE
Stop ignoring warnings from openj9.dataaccess and openj9.jvm

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -50,10 +50,8 @@ WARNINGS_AS_ERRORS_OPENJ9 := @WARNINGS_AS_ERRORS_OPENJ9@
 WARNING_MODULES := \
 	java.base \
 	jdk.management \
-	openj9.dataaccess \
 	openj9.dtfj \
 	openj9.dtfjview \
-	openj9.jvm \
 	openj9.sharedclasses \
 	openj9.traceformat \
 	#


### PR DESCRIPTION
There will be no warnings in openj9.dataaccess or openj9.jvm to be ignored after eclipse/openj9#10270 and eclipse/openj9#10271 are merged: this will contribute to ensuring it stays that way.