### PR TITLE
Modify hidden class tests for OpenJ9

### DIFF
--- a/test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java
@@ -120,7 +120,7 @@ public class BasicTest {
         assertTrue(c.getCanonicalName() == null);
 
         String hcName = "HiddenClass";
-        String hcSuffix = "0x[0-9a-f]+";
+        String hcSuffix = "[0-9a-fA-F]+";
         assertTrue(c.getName().matches(hcName + "/" + hcSuffix));
         assertTrue(c.descriptorString().matches("L" + hcName + "." + hcSuffix + ";"), c.descriptorString());
 
@@ -148,7 +148,7 @@ public class BasicTest {
         assertFalse(arrayType.isHidden());
 
         String hcName = "HiddenClass";
-        String hcSuffix = "0x[0-9a-f]+";
+        String hcSuffix = "[0-9a-fA-F]+";
         assertTrue(arrayType.getName().matches("\\[" + "L" + hcName + "/" + hcSuffix + ";"));
         assertTrue(arrayType.descriptorString().matches("\\[" + "L" + hcName + "." + hcSuffix + ";"));
 

--- a/test/jdk/java/lang/invoke/defineHiddenClass/TypeDescriptorTest.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/TypeDescriptorTest.java
@@ -113,11 +113,11 @@ public class TypeDescriptorTest {
     private Object[][] typeDescriptors() throws Exception {
         Class<?> hcArray = Array.newInstance(HC, 1, 1).getClass();
         return new Object[][] {
-                new Object[] { HC, "Ltest/HiddenClass.0x[0-9a-f]+;"},
-                new Object[] { hcArray, "\\[\\[Ltest/HiddenClass.0x[0-9a-f]+;"},
-                new Object[] { methodType(HC), "\\(\\)Ltest/HiddenClass.0x[0-9a-f]+;" },
-                new Object[] { methodType(void.class, HC), "\\(Ltest/HiddenClass.0x[0-9a-f]+;\\)V" },
-                new Object[] { methodType(void.class, HC, int.class, Object.class), "\\(Ltest/HiddenClass.0x[0-9a-f]+;ILjava/lang/Object;\\)V" }
+                new Object[] { HC, "Ltest/HiddenClass.[0-9a-fA-F]+;"},
+                new Object[] { hcArray, "\\[\\[Ltest/HiddenClass.[0-9a-fA-F]+;"},
+                new Object[] { methodType(HC), "\\(\\)Ltest/HiddenClass.[0-9a-fA-F]+;" },
+                new Object[] { methodType(void.class, HC), "\\(Ltest/HiddenClass.[0-9a-fA-F]+;\\)V" },
+                new Object[] { methodType(void.class, HC, int.class, Object.class), "\\(Ltest/HiddenClass.[0-9a-fA-F]+;ILjava/lang/Object;\\)V" }
         };
     }
 
@@ -146,9 +146,9 @@ public class TypeDescriptorTest {
     private Object[][] methodTypes() throws Exception {
         Class<?> hcArray = Array.newInstance(HC, 1, 1).getClass();
         return new Object[][] {
-                new Object[] { methodType(HC), "\\(\\)Ltest/HiddenClass.0x[0-9a-f]+;" },
-                new Object[] { methodType(void.class, hcArray), "\\(\\[\\[Ltest/HiddenClass.0x[0-9a-f]+;\\)V" },
-                new Object[] { methodType(void.class, int.class, HC), "\\(ILtest/HiddenClass.0x[0-9a-f]+;\\)V" }
+                new Object[] { methodType(HC), "\\(\\)Ltest/HiddenClass.[0-9a-fA-F]+;" },
+                new Object[] { methodType(void.class, hcArray), "\\(\\[\\[Ltest/HiddenClass.[0-9a-fA-F]+;\\)V" },
+                new Object[] { methodType(void.class, int.class, HC), "\\(ILtest/HiddenClass.[0-9a-fA-F]+;\\)V" }
         };
     }
 


### PR DESCRIPTION
JEP371 says the unique identifier appended to hidden class name 
is chosen by JVM implementation. 
OpenJ9 is appending romaddress, using upper case letter A-F
RI is appending 0xaddress, using lower case letter a-f.
openjdk test should not force the format of unique identifier to 
be the same as RI. 

Related to https://github.com/eclipse/openj9/pull/10471

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>