### PR TITLE
For easier reading, use OpenJ9 text instead of html license

### DIFF
--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -99,8 +99,11 @@ $(foreach file, \
 			$(LIB_DST_DIR))))
 
 $(call openj9_copy_files,, \
-	$(OPENJ9_TOPDIR)/longabout.html \
-	$(LEGAL_DST_DIR)/openj9-notices.html)
+	$(OPENJ9_TOPDIR)/LICENSE \
+	$(LEGAL_DST_DIR)/openj9-notices)
+$(call openj9_copy_files,, \
+	$(OPENJ9_TOPDIR)/epl-2.0.html \
+	$(LEGAL_DST_DIR)/epl-2.0.html)
 $(call openj9_copy_files,, \
         $(TOPDIR)/openj9-openjdk-notices \
         $(LEGAL_DST_DIR)/openj9-openjdk-notices)


### PR DESCRIPTION
Also include epl license which the OpenJ9 license refers to.

Same change as https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/344