### PR TITLE
Remove references to 'com.ibm.oti.vm.library.version'

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -514,7 +514,6 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 			-srcRoot jcl/ \
 			-xml jpp_configuration.xml \
 			-dest "$(call FixPath,$(JPP_DEST))" \
-			-macro:define "com.ibm.oti.vm.library.version=29" \
 			-tag:define "$(JPP_TAGS)"
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -226,7 +226,6 @@ grant codeBase "jrt:/openj9.cuda" {
     permission java.lang.RuntimePermission "loadLibrary.cuda4j29";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.lang.RuntimePermission "modifyThreadGroup";
-    permission java.util.PropertyPermission "com.ibm.oti.vm.library.version", "read";
 };
 
 grant codeBase "jrt:/openj9.gpu" {


### PR DESCRIPTION
* don't define unused preprocessor macro `com.ibm.oti.vm.library.version`
* remove unnecessary read permission for `com.ibm.oti.vm.library.version`

Depends on eclipse/openj9#10888.