### PR TITLE
Improve integration with openjdk build system

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -54,8 +54,21 @@ ifeq (,$(OPENJ9OMR_SHA))
   $(error Could not determine OMR SHA)
 endif
 
-# openjdk makeflags don't work with openj9/omr native compiles; override with number of CPUs which openj9 and omr need supplied
-override MAKEFLAGS := -j $(JOBS)
+ifeq (true,$(OPENJ9_ENABLE_CMAKE))
+  # If a logging level was specified that shows commands, tell cmake to do likewise.
+  ifneq (,$(or $(filter true,$(LOG_CMDLINES)),$(filter debug trace,$(LOG_LEVEL))))
+    MAKE_ARGS += VERBOSE=ON
+  endif
+else
+  # MAKEFLAGS, as inherited from openjdk, includes options (e.g. '-r' and '-R')
+  # that don't work well with OpenJ9 and OMR when not using cmake.
+  unexport MAKEFLAGS
+  # Filter out unwanted make flags.
+  MAKE_ARGS := $(filter-out -R -r -s,$(MAKE_ARGS))
+  ifneq (,$(JOBS))
+    MAKE_ARGS += -j $(JOBS)
+  endif
+endif # OPENJ9_ENABLE_CMAKE
 
 # Propagate configure option '--disable-warnings-as-errors-omr' to OMR.
 ifeq (false,$(WARNINGS_AS_ERRORS_OMR))
@@ -70,6 +83,8 @@ endif
 ifeq (windows,$(OPENJDK_TARGET_OS))
   # convert unix path to windows path
   FixPath = $(shell $(CYGPATH) -m $1)
+  # convert windows path to unix path
+  UnixPath = $(shell $(CYGPATH) -u $1)
   # set Visual Studio environment
   # wrap PATH in quotes as it contains spaces (unix path)
   # INCLUDE, LIB are already wrapped in quotes (windows paths)
@@ -78,13 +93,13 @@ ifeq (windows,$(OPENJDK_TARGET_OS))
   OPENJ9_BIN_OR_LIB_DIR := bin
 else
   FixPath = $1
+  UnixPath = $1
   EXPORT_MSVS_ENV_VARS :=
   OPENJ9_BIN_OR_LIB_DIR := lib
 endif
 
 .PHONY : \
 	build-j9 \
-	build-openj9-tools \
 	clean-j9 \
 	clean-j9-dist \
 	clean-openj9-thirdparty-binaries \
@@ -264,16 +279,6 @@ $(foreach file, \
 	$(eval $(call openj9_stage_buildspec_file,$(file))))
 
 J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
-JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
-
-build-openj9-tools :
-	@$(ECHO) Building OpenJ9 Java Preprocessor
-	@$(MKDIR) -p $(J9TOOLS_DIR)
-	$(MAKE) -C $(OPENJ9_TOPDIR)/sourcetools $(MAKEFLAGS) -f buildj9tools.mk \
-		BOOT_JDK=$(BOOT_JDK) \
-		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
-		JAVA_HOME=$(BOOT_JDK) \
-		$(call FixPath,$(JPP_JAR))
 
 stage-j9 :
 	@$(ECHO) Staging OpenJ9 runtime in $(OUTPUTDIR)/vm
@@ -320,36 +325,8 @@ $(OPENJ9_VM_BUILD_DIR)/omr/OMR_VERSION_STRING : $(call DependOnVariable, OPENJ9O
 	@$(MKDIR) -p $(@D)
 	$(ECHO) '#define OMR_VERSION_STRING "$(OPENJ9OMR_SHA)"' > $@
 
-CUSTOM_COMPILER_ENV_VARS :=
-
-ifneq (,$(OPENJ9_CC))
-  CUSTOM_COMPILER_ENV_VARS += CC="$(OPENJ9_CC)"
-endif
-ifneq (,$(OPENJ9_CXX))
-  CUSTOM_COMPILER_ENV_VARS += CXX="$(OPENJ9_CXX)"
-endif
-ifneq (,$(OPENJ9_DEVELOPER_DIR))
-  CUSTOM_COMPILER_ENV_VARS += DEVELOPER_DIR="$(OPENJ9_DEVELOPER_DIR)"
-endif
-ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-  ifneq (true,$(OPENJ9_ENABLE_CMAKE))
-    CUSTOM_COMPILER_ENV_VARS += J9VM_OPT_JITSERVER=1
-
-    ifneq (,$(OPENSSL_CFLAGS))
-      CUSTOM_COMPILER_ENV_VARS += OPENSSL_CFLAGS="$(OPENSSL_CFLAGS)"
-    endif
-
-    ifneq (,$(OPENSSL_DIR))
-      CUSTOM_COMPILER_ENV_VARS += OPENSSL_DIR="$(OPENSSL_DIR)"
-    endif
-
-    ifneq (,$(OPENSSL_BUNDLE_LIB_PATH))
-      CUSTOM_COMPILER_ENV_VARS += OPENSSL_BUNDLE_LIB_PATH="$(OPENSSL_BUNDLE_LIB_PATH)"
-    endif
-  endif # OPENJ9_ENABLE_CMAKE
-endif # OPENJ9_ENABLE_JITSERVER
-
 run-preprocessors-j9 : \
+	generate-j9jcl-sources \
 	$(OPENJ9_VM_BUILD_DIR)/omr/OMR_VERSION_STRING \
 	$(OPENJ9_VM_BUILD_DIR)/compiler/jit.version \
 	$(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h
@@ -357,15 +334,15 @@ run-preprocessors-j9 : \
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 
   CMAKE_ARGS := \
-    -C $(OPENJ9_TOPDIR)/runtime/cmake/caches/$(OPENJ9_BUILDSPEC).cmake \
-    -DBOOT_JDK="$(BOOT_JDK)" \
-    -DBUILD_ID=$(BUILD_ID) \
-    -DJ9VM_OMR_DIR="$(OPENJ9OMR_TOPDIR)" \
-    -DJAVA_SPEC_VERSION=$(VERSION_FEATURE) \
-    -DOMR_DDR=$(OPENJ9_ENABLE_DDR) \
-    -DOPENJ9_BUILD=true \
-    -DOPENJ9_SHA=$(OPENJ9_SHA) \
-    #
+	-C $(OPENJ9_TOPDIR)/runtime/cmake/caches/$(OPENJ9_BUILDSPEC).cmake \
+	-DBOOT_JDK="$(BOOT_JDK)" \
+	-DBUILD_ID=$(BUILD_ID) \
+	-DJ9VM_OMR_DIR="$(OPENJ9OMR_TOPDIR)" \
+	-DJAVA_SPEC_VERSION=$(VERSION_FEATURE) \
+	-DOMR_DDR=$(OPENJ9_ENABLE_DDR) \
+	-DOPENJ9_BUILD=true \
+	-DOPENJ9_SHA=$(OPENJ9_SHA) \
+	#
 
   ifeq (windows,$(OPENJDK_TARGET_OS))
     CMAKE_ARGS += -DCMAKE_TOOLCHAIN_FILE="$(OUTPUTDIR)/toolchain-win.cmake"
@@ -421,10 +398,8 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
     CMAKE_ARGS += -DJ9VM_OPT_JITSERVER=OFF
   endif # OPENJ9_ENABLE_JITSERVER
 
-  CMAKE_ARGS += $(EXTRA_CMAKE_ARGS)
-
   ifeq (true,$(OPENJ9_ENABLE_CUDA))
-    CMAKE_ARGS += -DJ9VM_OPT_CUDA=ON -DOMR_CUDA_HOME="$(CUDA_HOME)"
+    CMAKE_ARGS += -DJ9VM_OPT_CUDA=ON -DOMR_CUDA_HOME="$(call UnixPath,$(CUDA_HOME))"
   else # OPENJ9_ENABLE_CUDA
     CMAKE_ARGS += -DJ9VM_OPT_CUDA=OFF
   endif # OPENJ9_ENABLE_CUDA
@@ -443,9 +418,12 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
     CMAKE_ARGS += -DJ9VM_OPT_OPENJDK_METHODHANDLE=OFF
   endif # OPENJ9_ENABLE_OPENJDK_METHODHANDLES
 
+  # Do this last so extra args take precedence.
+  CMAKE_ARGS += $(EXTRA_CMAKE_ARGS)
+
 $(OUTPUTDIR)/vm/cmake.stamp :
 	@$(MKDIR) -p $(@D)
-	cd $(@D) && $(CMAKE) $(CMAKE_ARGS) $(OPENJ9_TOPDIR)
+	cd $(@D) && $(EXPORT_MSVS_ENV_VARS) $(CMAKE) $(CMAKE_ARGS) $(OPENJ9_TOPDIR)
 	$(TOUCH) $@
 
 run-preprocessors-j9 : $(OUTPUTDIR)/vm/cmake.stamp
@@ -454,11 +432,9 @@ else # OPENJ9_ENABLE_CMAKE
 
 run-preprocessors-j9 : stage-j9
 	@$(ECHO) Running OpenJ9 preprocessors with OPENJ9_BUILDSPEC: $(OPENJ9_BUILDSPEC)
-	export BOOT_JDK=$(BOOT_JDK) $(EXPORT_MSVS_ENV_VARS) \
-		OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
-		&& $(MAKE) -C $(OUTPUTDIR)/vm $(MAKEFLAGS) -f $(OPENJ9_TOPDIR)/runtime/buildtools.mk \
+	+BOOT_JDK=$(BOOT_JDK) $(EXPORT_MSVS_ENV_VARS) OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
+		$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm -f $(OPENJ9_TOPDIR)/runtime/buildtools.mk \
 			BUILD_ID=$(BUILD_ID) \
-			CMAKE=$(CMAKE) \
 			DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
 			EXTRA_CONFIGURE_ARGS=$(OMR_EXTRA_CONFIGURE_ARGS) \
 			FREEMARKER_JAR="$(FREEMARKER_JAR)" \
@@ -473,21 +449,50 @@ run-preprocessors-j9 : stage-j9
 
 endif # OPENJ9_ENABLE_CMAKE
 
+CUSTOM_COMPILER_ENV_VARS :=
+
+ifneq (,$(OPENJ9_CC))
+  CUSTOM_COMPILER_ENV_VARS += CC="$(OPENJ9_CC)"
+endif
+ifneq (,$(OPENJ9_CXX))
+  CUSTOM_COMPILER_ENV_VARS += CXX="$(OPENJ9_CXX)"
+endif
+ifneq (,$(OPENJ9_DEVELOPER_DIR))
+  CUSTOM_COMPILER_ENV_VARS += DEVELOPER_DIR="$(OPENJ9_DEVELOPER_DIR)"
+endif
+ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
+  ifneq (true,$(OPENJ9_ENABLE_CMAKE))
+    CUSTOM_COMPILER_ENV_VARS += J9VM_OPT_JITSERVER=1
+
+    ifneq (,$(OPENSSL_CFLAGS))
+      CUSTOM_COMPILER_ENV_VARS += OPENSSL_CFLAGS="$(OPENSSL_CFLAGS)"
+    endif
+
+    ifneq (,$(OPENSSL_DIR))
+      CUSTOM_COMPILER_ENV_VARS += OPENSSL_DIR="$(OPENSSL_DIR)"
+    endif
+
+    ifneq (,$(OPENSSL_BUNDLE_LIB_PATH))
+      CUSTOM_COMPILER_ENV_VARS += OPENSSL_BUNDLE_LIB_PATH="$(OPENSSL_BUNDLE_LIB_PATH)"
+    endif
+  endif # OPENJ9_ENABLE_CMAKE
+endif # OPENJ9_ENABLE_JITSERVER
+
 ifneq (true,$(OPENJ9_ENABLE_DDR))
   DDR_COMMAND :=
 else ifeq (true,$(OPENJ9_ENABLE_CMAKE))
-  DDR_COMMAND := $(MAKE) -C $(OPENJ9_VM_BUILD_DIR) j9ddr
+  DDR_COMMAND := $(EXPORT_MSVS_ENV_VARS) $(MAKE) $(MAKE_ARGS) -C $(OPENJ9_VM_BUILD_DIR) j9ddr
 else
   DDR_COMMAND := CC="$(CC)" CXX="$(CXX)" $(EXPORT_MSVS_ENV_VARS) \
-	$(MAKE) -C $(OUTPUTDIR)/vm/ddr -f run_omrddrgen.mk
+	$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm/ddr -f run_omrddrgen.mk
 endif # OPENJ9_ENABLE_DDR
 
 build-j9 : run-preprocessors-j9
 	@$(ECHO) Compiling OpenJ9 in $(OUTPUTDIR)/vm
-	OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) $(CUSTOM_COMPILER_ENV_VARS) \
-		$(MAKE) -C $(OUTPUTDIR)/vm $(MAKEFLAGS) all
+	+OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) $(CUSTOM_COMPILER_ENV_VARS) \
+		$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm all
 	@$(ECHO) OpenJ9 compile complete
-	$(DDR_COMMAND)
+	+$(DDR_COMMAND)
 
 J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl_sources.done
 
@@ -495,14 +500,21 @@ recur_wildcard = $(foreach dir,$(wildcard $1/*),$(call recur_wildcard,$(dir),$2)
 AllJclSource   = $(call recur_wildcard,$(OPENJ9_TOPDIR)/jcl/src,*.java)
 
 JPP_DEST := $(SUPPORT_OUTPUTDIR)/j9jcl_sources
-
+JPP_JAR  := $(J9TOOLS_DIR)/jpp.jar
 JPP_TAGS := PLATFORM-$(OPENJ9_PLATFORM_CODE)
 
 ifeq (true,$(OPENJ9_ENABLE_OPENJDK_METHODHANDLES))
-  JPP_TAGS := $(JPP_TAGS);OPENJDK_METHODHANDLES
+  JPP_TAGS += OPENJDK_METHODHANDLES
 endif # OPENJ9_ENABLE_OPENJDK_METHODHANDLES
 
 $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
+	@$(ECHO) Building OpenJ9 Java Preprocessor
+	@$(MKDIR) -p $(J9TOOLS_DIR)
+	$(MAKE) $(MAKE_ARGS) -C $(OPENJ9_TOPDIR)/sourcetools -f buildj9tools.mk \
+		BOOT_JDK=$(BOOT_JDK) \
+		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
+		JAVA_HOME=$(BOOT_JDK) \
+		$(call FixPath,$(JPP_JAR))
 	@$(ECHO) Generating J9JCL sources
 	@$(BOOT_JDK)/bin/java \
 		-cp "$(call FixPath,$(JPP_JAR))" \
@@ -514,14 +526,14 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 			-srcRoot jcl/ \
 			-xml jpp_configuration.xml \
 			-dest "$(call FixPath,$(JPP_DEST))" \
-			-tag:define "$(JPP_TAGS)"
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@
 
 generate-j9jcl-sources : $(J9JCL_SOURCES_DONEFILE)
 
 clean-j9 : clean-openj9-thirdparty-binaries
-	$(MAKE) -C $(OUTPUTDIR)/vm clean
+	+$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm clean
 
 clean-j9-dist : clean-openj9-thirdparty-binaries
 	$(RM) -fdr $(OUTPUTDIR)/vm

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -93,8 +93,8 @@ J9JDK_EXT_VERSION       := HEAD
 J9JDK_EXT_NAME          := Extensions for OpenJDK for Eclipse OpenJ9
 
 # required by CMake
-export CMAKE               := @CMAKE@
-export OPENJ9_ENABLE_CMAKE := @OPENJ9_ENABLE_CMAKE@
+CMAKE                   := @CMAKE@
+OPENJ9_ENABLE_CMAKE     := @OPENJ9_ENABLE_CMAKE@
 
 # required by UMA
 FREEMARKER_JAR          := @FREEMARKER_JAR@
@@ -144,17 +144,18 @@ else
 	$1
 endif
 
-# OPENSSL
+# OpenSSL
 BUILD_OPENSSL           := @BUILD_OPENSSL@
 OPENSSL_BUNDLE_LIB_PATH := @OPENSSL_BUNDLE_LIB_PATH@
 OPENSSL_CFLAGS          := @OPENSSL_CFLAGS@
 OPENSSL_DIR             := @OPENSSL_DIR@
 WITH_OPENSSL            := @WITH_OPENSSL@
 
+# Use '=' instead of ':=' because bootcycle-spec.gmk overrides OUTPUTDIR.
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
-  OPENJ9_VM_BUILD_DIR := $(OUTPUTDIR)/vm/runtime
+  OPENJ9_VM_BUILD_DIR = $(OUTPUTDIR)/vm/runtime
 else
-  OPENJ9_VM_BUILD_DIR := $(OUTPUTDIR)/vm
+  OPENJ9_VM_BUILD_DIR = $(OUTPUTDIR)/vm
 endif
 
 # Disable all hotspot features.

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -22,8 +22,8 @@ CLEAN_DIRS += vm
 
 .PHONY : \
 	debug-image \
+	generate-j9jcl-sources \
 	j9vm-build \
-	openj9-create-main-targets-include \
 	test-image-openj9 \
 	#
 
@@ -43,17 +43,16 @@ OPENJ9_MAKE := $(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/OpenJ9.gmk
 # modules specific to OpenJ9 will be found and included in that set. The next two
 # rules make that happen.
 
-create-main-targets-include : openj9-create-main-targets-include
+create-main-targets-include java.base-gensrc : generate-j9jcl-sources
 
-openj9-create-main-targets-include :
-	@$(OPENJ9_MAKE) build-openj9-tools
-	@$(OPENJ9_MAKE) generate-j9jcl-sources
+generate-j9jcl-sources :
+	@+$(OPENJ9_MAKE) $@
 
 j9vm-build : buildtools-langtools
   ifeq ($(BUILD_OPENSSL),yes)
-	@$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/openssl.gmk
+	@+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/openssl.gmk
   endif # BUILD_OPENSSL
-	@$(OPENJ9_MAKE) build-j9
+	@+$(OPENJ9_MAKE) build-j9
 
 # Modules with content created by j9vm-build:
 OPENJ9_VM_MODULES := \
@@ -70,7 +69,7 @@ $(addsuffix -copy, $(OPENJ9_VM_MODULES)) : j9vm-build
 java.base-libs : java.base-copy
 
 debug-image : exploded-image
-	+$(MAKE) -f $(TOPDIR)/closed/DebugImage.gmk SPEC=$(SPEC)
+	+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/DebugImage.gmk
 
 all-images : debug-image
 
@@ -80,7 +79,7 @@ test-image : test-image-openj9
 
 # If not cross-compiling, capture 'java -version' output.
 test-image-openj9 : exploded-image
-	@$(OPENJ9_MAKE) openj9_test_image
+	@+$(OPENJ9_MAKE) openj9_test_image
 ifneq ($(COMPILE_TYPE), cross)
 	$(JDK_OUTPUTDIR)/bin/java -version 2>&1 | $(TEE) $(TEST_IMAGE_DIR)/openj9/java-version.txt
 endif
@@ -92,10 +91,10 @@ ifeq (true,$(OPENJ9_ENABLE_DDR))
 .PHONY : openj9.dtfj-ddr-gen openj9.dtfj-ddr-jar
 
 openj9.dtfj-ddr-gen : j9vm-build $(addsuffix -java, java.base java.desktop openj9.dtfj openj9.traceformat)
-	+$(MAKE) -f $(TOPDIR)/closed/DDR.gmk SPEC=$(SPEC) generate
+	+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/DDR.gmk generate
 
 openj9.dtfj-ddr-jar : openj9.dtfj-ddr-gen
-	+$(MAKE) -f $(TOPDIR)/closed/DDR.gmk SPEC=$(SPEC) build_jar
+	+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/DDR.gmk build_jar
 
 openj9.dtfj-launchers : openj9.dtfj-ddr-jar
 
@@ -110,12 +109,11 @@ ifneq (true,$(BUILD_FAILURE_HANDLER))
 endif
 
 clean-docs : clean-openj9-only-docs
+
 .PHONY : clean-openj9-only-docs
+
 clean-openj9-only-docs :
-	@$(PRINTF) "Cleaning $(SUPPORT_OUTPUTDIR)/openj9-docs ...\n"
-	$(RM) -rf $(SUPPORT_OUTPUTDIR)/openj9-docs
-	@$(PRINTF) "Cleaning $(IMAGES_OUTPUTDIR)/openj9-docs ...\n"
-	$(RM) -rf $(IMAGES_OUTPUTDIR)/openj9-docs
-	@$(PRINTF) " done\n"
+	@$(ECHO) Cleaning openj9-only-docs ...
+	$(RM) -rf $(IMAGES_OUTPUTDIR)/openj9-docs $(SUPPORT_OUTPUTDIR)/openj9-docs
 
 ALL_TARGETS += clean-openj9-only-docs

--- a/closed/openj9_version_info.h.in
+++ b/closed/openj9_version_info.h.in
@@ -7,7 +7,7 @@
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.
  *
- * IBM designates this particular file as subject to the "Classpath" exception 
+ * IBM designates this particular file as subject to the "Classpath" exception
  * as provided by IBM in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT


### PR DESCRIPTION
This is essentially a replay of ibmruntimes/openj9-openjdk-jdk11#355 for Java 15, eliminating unnecessary differences relative to Java 11.