### PR TITLE
Add OpenJ9 modules as platform modules

### DIFF
--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -23,6 +23,13 @@ BOOT_MODULES += \
     openj9.sharedclasses \
     #
 
+PLATFORM_MODULES += \
+	openj9.cuda \
+	openj9.dataaccess \
+	openj9.gpu \
+	openj9.zosconditionhandling \
+	#
+
 MODULES_FILTER += \
     jdk.aot \
     jdk.hotspot.agent \


### PR DESCRIPTION
Referring to https://openjdk.java.net/jeps/261 modules which are part of
the java platform, and not tools, should be platform modules. In
particular this is a problem for the ibm.jzos platform module which
requires openj9.dataaccess.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>