### PR TITLE
Revert "JDK changes to support JEP383 with OpenJ9"

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -50,7 +50,7 @@ import java.util.function.BiFunction;
 /* package */ class IndirectVarHandle extends VarHandle {
 
     @Stable
-    private final MethodHandle[] handleMap;
+    private final MethodHandle[] handleMap = new MethodHandle[AccessMode.values().length];
     private final VarHandle directTarget; // cache, for performance reasons
     private final VarHandle target;
     private final BiFunction<AccessMode, MethodHandle, MethodHandle> handleFactory;
@@ -64,7 +64,6 @@ import java.util.function.BiFunction;
         this.directTarget = target.asDirect();
         this.value = value;
         this.coordinates = coordinates;
-        this.handleMap = this.handleTable = VarHandle.populateMHsJEP383(target, handleFactory);
     }
 
     @Override
@@ -101,15 +100,14 @@ import java.util.function.BiFunction;
     MethodHandle getMethodHandle(int mode) {
         MethodHandle handle = handleMap[mode];
         if (handle == null) {
-            /* OpenJ9 pre-initializes the handleMap in the constructor. So, there is no need to reapply handleFactory here. */
-            handle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
+            MethodHandle targetHandle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
+            handle = handleMap[mode] = handleFactory.apply(AccessMode.values()[mode], targetHandle);
         }
         return handle;
     }
 
     @Override
     public MethodHandle toMethodHandle(AccessMode accessMode) {
-        MethodHandle mh = getMethodHandle(accessMode.ordinal());
-        return MethodHandles.insertArguments(mh, mh.type().parameterCount() - 1, directTarget);
+        return getMethodHandle(accessMode.ordinal()).bindTo(directTarget);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -343,7 +343,13 @@ final class VarHandles {
     }
 
     private static VarHandle maybeAdapt(VarHandle target) {
-        /* This optimization is disabled in OpenJ9. */
+        if (!VAR_HANDLE_IDENTITY_ADAPT) return target;
+        target = filterValue(target,
+                        MethodHandles.identity(target.varType()), MethodHandles.identity(target.varType()));
+        MethodType mtype = target.accessModeType(VarHandle.AccessMode.GET).dropParameterTypes(0, 1);
+        for (int i = 0 ; i < mtype.parameterCount() ; i++) {
+            target = filterCoordinates(target, i, MethodHandles.identity(mtype.parameterType(i)));
+        }
         return target;
     }
 
@@ -619,7 +625,7 @@ final class VarHandles {
             }
         } else if (handle instanceof DelegatingMethodHandle) {
             noCheckedExceptions(((DelegatingMethodHandle)handle).getTarget());
-        } else if (handle instanceof BoundMethodHandle) {
+        } else {
             //bound
             BoundMethodHandle boundHandle = (BoundMethodHandle)handle;
             for (int i = 0 ; i < boundHandle.fieldCount() ; i++) {
@@ -627,11 +633,6 @@ final class VarHandles {
                 if (arg instanceof MethodHandle){
                     noCheckedExceptions((MethodHandle) arg);
                 }
-            }
-        } else {
-            /* Temporary code to handle OpenJ9's MethodHandle implementation. This will be removed in a future release. */
-            if (MethodHandles.hasCheckedException(handle)) {
-                throw newIllegalArgumentException("Cannot adapt a var handle with a method handle which throws checked exceptions");
             }
         }
     }


### PR DESCRIPTION
This reverts commit 2b5bc6b999c8f9a1c918b5628c64f55a59246b95.

This should only be merged once OpenJDK MH support is enabled in OpenJ9.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>